### PR TITLE
Adding a link to an example of custom receiver in PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Please see the initial [documentation](http://go.microsoft.com/fwlink/?LinkId=69
 - [Slack](/samples/SlackReceiver)
 - [Stripe](/samples/StripeReceiver)
 - [Zendesk](/samples/ZendeskReceiver)
+- [Custom Receiver (PHP)] (https://gist.github.com/gbaldera/aa40aa70bc54582e7e8050cadd72470b)
 
 ###Resources
 * Overview


### PR DESCRIPTION
Recently I had to integrate an old PHP application with a new ASP.Net one using Webhooks, so I shared the code of the custom receiver hoping it helps others with the same needs.
